### PR TITLE
Fixed issue with default pipeline

### DIFF
--- a/bld_config/src/definitions.rs
+++ b/bld_config/src/definitions.rs
@@ -31,7 +31,7 @@ runs-on: machine
 steps: 
 - name: echo 
   exec:
-  - sh: echo 'hello world'
+  - echo 'hello world'
 ";
 
 pub fn default_server_config() -> String {


### PR DESCRIPTION
Removed "sh:" from the echo command in the default pipeline.