### PR TITLE
Feat/add tls options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "diesel",
  "futures",
  "futures-util",
+ "openssl",
  "serde",
  "serde_derive",
  "serde_json",
@@ -555,6 +556,7 @@ dependencies = [
  "bld_core",
  "diesel",
  "futures",
+ "openssl",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1489,9 +1491,9 @@ checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1521,9 +1523,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "itoa",
  "log",
  "mime",
+ "openssl",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",

--- a/bld_commands/Cargo.toml
+++ b/bld_commands/Cargo.toml
@@ -10,7 +10,7 @@ actix = "0.13.0"
 actix-codec = "0.5.0"
 actix-web = { version = "4.0.1", features = ["openssl"] }
 anyhow = "1.0.40"
-awc = "3.0.0"
+awc = { version = "3.0.0", features = ["openssl"] }
 bld_config = { path = "../bld_config" }
 bld_utils = { path = "../bld_utils" }
 bld_core = { path = "../bld_core" }

--- a/bld_commands/src/auth/method.rs
+++ b/bld_commands/src/auth/method.rs
@@ -80,7 +80,9 @@ impl Login for OAuth2Info {
             .exchange_code(code)
             .request(http_client)
             .map_err(|e| anyhow!(e))?;
+
         persist_access_token(server, token_res.access_token().secret())?;
+
         Ok(String::new())
     }
 }

--- a/bld_commands/src/config/command.rs
+++ b/bld_commands/src/config/command.rs
@@ -36,10 +36,20 @@ impl ConfigCommand {
         println!("  - host: {}", local.server.host);
         println!("  - port: {}", local.server.port);
         println!("  - pipelines: {}", local.server.pipelines);
+        if let Some(tls) = &local.server.tls {
+            println!("  - tls:");
+            println!("    - cert-chain:  {}", tls.cert_chain);
+            println!("    - private-key: {}", tls.private_key);
+        }
         println!("- supervisor:");
         println!("  - host: {}", local.supervisor.host);
         println!("  - port: {}", local.supervisor.port);
         println!("  - workers: {}", local.supervisor.workers);
+        if let Some(tls) = &local.supervisor.tls {
+            println!("  - tls:");
+            println!("    - cert-chain:  {}", tls.cert_chain);
+            println!("    - private-key: {}", tls.private_key);
+        }
         println!("- logs: {}", local.logs);
         println!("- db: {}", local.db);
         println!("- docker-url: {}", local.docker_url);
@@ -53,6 +63,7 @@ impl ConfigCommand {
             println!("- name: {}", server.name);
             println!("- host: {}", server.host);
             println!("- port: {}", server.port);
+            println!("- tls:  {}", server.tls);
             match &server.auth {
                 Auth::OAuth2(info) => {
                     println!("- auth:");

--- a/bld_commands/src/hist/command.rs
+++ b/bld_commands/src/hist/command.rs
@@ -46,7 +46,8 @@ impl BldCommand for HistCommand {
             },
             None => (&srv.name, &srv.auth),
         };
-        let url = format!("http://{}:{}/hist", srv.host, srv.port);
+        let protocol = srv.http_protocol();
+        let url = format!("{protocol}://{}:{}/hist", srv.host, srv.port);
         let headers = request::headers(name, auth)?;
         debug!("sending http request to {}", url);
         System::new().block_on(async move {

--- a/bld_commands/src/inspect/command.rs
+++ b/bld_commands/src/inspect/command.rs
@@ -60,7 +60,8 @@ impl BldCommand for InspectCommand {
             },
             None => (&srv.name, &srv.auth),
         };
-        let url = format!("http://{}:{}/inspect", srv.host, srv.port);
+        let protocol = srv.http_protocol();
+        let url = format!("{protocol}://{}:{}/inspect", srv.host, srv.port);
         let headers = request::headers(name, auth)?;
         debug!("sending http request to {}", url);
         System::new().block_on(async move {

--- a/bld_commands/src/list/command.rs
+++ b/bld_commands/src/list/command.rs
@@ -50,7 +50,7 @@ impl BldCommand for ListCommand {
         let protocol = srv.http_protocol();
         let url = format!("{protocol}://{}:{}/list", srv.host, srv.port);
         let headers = request::headers(name, auth)?;
-        debug!("sending http request to {}", url);
+        debug!("sending {protocol} request to {}", url);
         System::new()
             .block_on(async move { request::get(url, headers).await.map(|r| println!("{r}")) })
     }

--- a/bld_commands/src/list/command.rs
+++ b/bld_commands/src/list/command.rs
@@ -47,7 +47,8 @@ impl BldCommand for ListCommand {
             },
             None => (&srv.name, &srv.auth),
         };
-        let url = format!("http://{}:{}/list", srv.host, srv.port);
+        let protocol = srv.http_protocol();
+        let url = format!("{protocol}://{}:{}/list", srv.host, srv.port);
         let headers = request::headers(name, auth)?;
         debug!("sending http request to {}", url);
         System::new()

--- a/bld_commands/src/monit/command.rs
+++ b/bld_commands/src/monit/command.rs
@@ -22,6 +22,7 @@ static LAST: &str = "last";
 struct MonitConnectionInfo {
     host: String,
     port: i64,
+    protocol: String,
     headers: HashMap<String, String>,
     pip_id: Option<String>,
     pip_name: Option<String>,
@@ -91,6 +92,7 @@ impl BldCommand for MonitCommand {
         spawn(MonitConnectionInfo {
             host: srv.host.to_string(),
             port: srv.port,
+            protocol: srv.ws_protocol(),
             headers: headers(name, auth)?,
             pip_id,
             pip_name,
@@ -100,7 +102,7 @@ impl BldCommand for MonitCommand {
 }
 
 async fn request(info: MonitConnectionInfo) -> Result<()> {
-    let url = format!("ws://{}:{}/ws-monit/", info.host, info.port);
+    let url = format!("{}://{}:{}/ws-monit/", info.protocol, info.host, info.port);
     debug!("establishing web socket connection on {}", url);
     let mut client = Client::new().ws(url);
     for (key, value) in info.headers.iter() {

--- a/bld_commands/src/monit/command.rs
+++ b/bld_commands/src/monit/command.rs
@@ -3,6 +3,7 @@ use crate::BldCommand;
 use actix::{io::SinkWrite, Actor, StreamHandler};
 use actix_web::rt::System;
 use anyhow::{anyhow, Result};
+use awc::http::Version;
 use awc::Client;
 use bld_config::{definitions::VERSION, BldConfig};
 use bld_server::requests::MonitInfo;
@@ -103,21 +104,29 @@ impl BldCommand for MonitCommand {
 
 async fn request(info: MonitConnectionInfo) -> Result<()> {
     let url = format!("{}://{}:{}/ws-monit/", info.protocol, info.host, info.port);
+
     debug!("establishing web socket connection on {}", url);
-    let mut client = Client::new().ws(url);
+
+    let client = Client::builder()
+        .max_http_version(Version::HTTP_11)
+        .finish();
+    let mut client = client.ws(url);
     for (key, value) in info.headers.iter() {
         client = client.header(&key[..], &value[..]);
     }
     let (_, framed) = client.connect().await.map_err(|e| anyhow!(e.to_string()))?;
+
     let (sink, stream) = framed.split();
     let addr = MonitClient::create(|ctx| {
         MonitClient::add_stream(stream, ctx);
         MonitClient::new(SinkWrite::new(sink, ctx))
     });
+
     debug!(
         "sending data over: {:?} {:?} {}",
         info.pip_id, info.pip_name, info.pip_last
     );
+
     addr.send(MonitInfo::new(info.pip_id, info.pip_name, info.pip_last))
         .await?;
     Ok(())

--- a/bld_commands/src/pull/command.rs
+++ b/bld_commands/src/pull/command.rs
@@ -73,7 +73,7 @@ impl BldCommand for PullCommand {
         };
         let headers = request::headers(name, auth)?;
         System::new().block_on(async move {
-            do_pull(srv.host.clone(), srv.port, headers, pip, ignore).await
+            do_pull(srv.host.clone(), srv.port, srv.http_protocol(), headers, pip, ignore).await
         })
     }
 }
@@ -81,13 +81,14 @@ impl BldCommand for PullCommand {
 async fn do_pull(
     host: String,
     port: i64,
+    protocol: String,
     headers: HashMap<String, String>,
     name: String,
     ignore_deps: bool,
 ) -> Result<()> {
     let mut pipelines = vec![name.to_string()];
     if !ignore_deps {
-        let metadata_url = format!("http://{host}:{port}/deps");
+        let metadata_url = format!("{protocol}://{host}:{port}/deps");
         debug!("sending http request to {metadata_url}");
         print!("Fetching metadata for dependecies...");
         let mut deps = request::post(metadata_url, headers.clone(), name)
@@ -104,7 +105,7 @@ async fn do_pull(
         pipelines.append(&mut deps);
     }
     for pipeline in pipelines.iter() {
-        let url = format!("http://{host}:{port}/pull");
+        let url = format!("{protocol}://{host}:{port}/pull");
         debug!("sending http request to {url}");
         print!("Pulling pipeline {pipeline}...");
         let _ = request::post(url, headers.clone(), pipeline.to_string())

--- a/bld_commands/src/pull/command.rs
+++ b/bld_commands/src/pull/command.rs
@@ -73,7 +73,15 @@ impl BldCommand for PullCommand {
         };
         let headers = request::headers(name, auth)?;
         System::new().block_on(async move {
-            do_pull(srv.host.clone(), srv.port, srv.http_protocol(), headers, pip, ignore).await
+            do_pull(
+                srv.host.clone(),
+                srv.port,
+                srv.http_protocol(),
+                headers,
+                pip,
+                ignore,
+            )
+            .await
         })
     }
 }

--- a/bld_commands/src/push/command.rs
+++ b/bld_commands/src/push/command.rs
@@ -71,7 +71,7 @@ impl BldCommand for PushCommand {
         };
         let headers = request::headers(name, auth)?;
         System::new().block_on(async move {
-            do_push(srv.host.clone(), srv.port, headers, pip, ignore).await
+            do_push(srv.host.clone(), srv.port, srv.http_protocol(), headers, pip, ignore).await
         })
     }
 }
@@ -79,6 +79,7 @@ impl BldCommand for PushCommand {
 async fn do_push(
     host: String,
     port: i64,
+    protocol: String,
     headers: HashMap<String, String>,
     name: String,
     ignore_deps: bool,
@@ -102,7 +103,7 @@ async fn do_push(
     }
     for info in pipelines.into_iter() {
         print!("Pushing {}...", info.name);
-        let url = format!("http://{}:{}/push", host, port);
+        let url = format!("{protocol}://{}:{}/push", host, port);
         debug!("sending http request to {}", url);
         let _ = request::post(url.clone(), headers.clone(), info)
             .await

--- a/bld_commands/src/push/command.rs
+++ b/bld_commands/src/push/command.rs
@@ -71,7 +71,15 @@ impl BldCommand for PushCommand {
         };
         let headers = request::headers(name, auth)?;
         System::new().block_on(async move {
-            do_push(srv.host.clone(), srv.port, srv.http_protocol(), headers, pip, ignore).await
+            do_push(
+                srv.host.clone(),
+                srv.port,
+                srv.http_protocol(),
+                headers,
+                pip,
+                ignore,
+            )
+            .await
         })
     }
 }

--- a/bld_commands/src/remove/command.rs
+++ b/bld_commands/src/remove/command.rs
@@ -67,7 +67,7 @@ async fn do_remove(matches: &ArgMatches) -> Result<()> {
     let protocol = srv.http_protocol();
     let url = format!("{protocol}://{}:{}/remove", srv.host, srv.port);
     let headers = request::headers(name, auth)?;
-    debug!("sending http request to {url}");
+    debug!("sending {protocol} request to {url}");
     request::post(url, headers, pipeline).await.map(|r| {
         println!("{r}");
     })

--- a/bld_commands/src/remove/command.rs
+++ b/bld_commands/src/remove/command.rs
@@ -64,7 +64,8 @@ async fn do_remove(matches: &ArgMatches) -> Result<()> {
         },
         None => (&srv.name, &srv.auth),
     };
-    let url = format!("http://{}:{}/remove", srv.host, srv.port);
+    let protocol = srv.http_protocol();
+    let url = format!("{protocol}://{}:{}/remove", srv.host, srv.port);
     let headers = request::headers(name, auth)?;
     debug!("sending http request to {url}");
     request::post(url, headers, pipeline).await.map(|r| {

--- a/bld_commands/src/run/command.rs
+++ b/bld_commands/src/run/command.rs
@@ -98,6 +98,7 @@ impl BldCommand for RunCommand {
                 bld_runner::on_server(ExecConnectionInfo {
                     host: srv.host.clone(),
                     port: srv.port,
+                    protocol: srv.ws_protocol(),
                     headers: headers(srv_name, auth)?,
                     detach,
                     pipeline,

--- a/bld_commands/src/stop/command.rs
+++ b/bld_commands/src/stop/command.rs
@@ -56,7 +56,8 @@ impl BldCommand for StopCommand {
             },
             None => (&srv.name, &srv.auth),
         };
-        let url = format!("http://{}:{}/stop", srv.host, srv.port);
+        let protocol = srv.http_protocol();
+        let url = format!("{protocol}://{}:{}/stop", srv.host, srv.port);
         let headers = request::headers(name, auth)?;
         System::new().block_on(async move {
             request::post(url, headers, id).await.map(|r| {

--- a/bld_commands/src/worker/command.rs
+++ b/bld_commands/src/worker/command.rs
@@ -140,8 +140,13 @@ async fn connect_to_supervisor(
     config: Arc<BldConfig>,
     mut worker_rx: Receiver<WorkerMessages>,
 ) -> Result<()> {
+    let protocol = if config.local.supervisor.tls.is_some() {
+        "wss"
+    } else {
+        "ws"
+    };
     let url = format!(
-        "ws://{}:{}/ws-worker/",
+        "{protocol}://{}:{}/ws-worker/",
         config.local.supervisor.host, config.local.supervisor.port
     );
 

--- a/bld_commands/src/worker/command.rs
+++ b/bld_commands/src/worker/command.rs
@@ -4,6 +4,7 @@ use actix::io::SinkWrite;
 use actix::{Actor, StreamHandler};
 use actix_web::rt::{spawn, System};
 use anyhow::{anyhow, Result};
+use awc::http::Version;
 use awc::Client;
 use bld_config::BldConfig;
 use bld_core::context::Context;
@@ -152,7 +153,10 @@ async fn connect_to_supervisor(
 
     debug!("establishing web socket connection on {}", url);
 
-    let client = Client::new().ws(url).connect();
+    let client = Client::builder()
+        .max_http_version(Version::HTTP_11)
+        .finish();
+    let client = client.ws(url).connect();
     let (_, framed) = client.await.map_err(|e| {
         error!("{e}");
         anyhow!(e.to_string())

--- a/bld_config/src/auth.rs
+++ b/bld_config/src/auth.rs
@@ -13,7 +13,7 @@ pub struct OAuth2Info {
 }
 
 impl OAuth2Info {
-    pub fn load(host: &str, port: i64, yaml: &Yaml) -> Result<Box<Self>> {
+    pub fn load(host: &str, port: i64, protocol: &str, yaml: &Yaml) -> Result<Box<Self>> {
         let auth_url = AuthUrl::new(
             yaml["auth-url"]
                 .as_str()
@@ -46,7 +46,7 @@ impl OAuth2Info {
             .filter(|y| y.is_some())
             .map(|y| Scope::new(y.unwrap().to_string()))
             .collect();
-        let redirect_url = RedirectUrl::new(format!("http://{host}:{port}/authRedirect"))?;
+        let redirect_url = RedirectUrl::new(format!("{protocol}://{host}:{port}/authRedirect"))?;
         Ok(Box::new(Self {
             auth_url,
             token_url,

--- a/bld_config/src/lib.rs
+++ b/bld_config/src/lib.rs
@@ -4,18 +4,18 @@ mod errors;
 mod local;
 mod path;
 mod remote;
-mod tls;
 mod server;
 mod supervisor;
+mod tls;
 
 pub use auth::*;
 pub use errors::*;
 pub use local::*;
 pub use path::*;
 pub use remote::*;
-pub use tls::*;
 pub use server::*;
 pub use supervisor::*;
+pub use tls::*;
 
 use anyhow::Result;
 use std::path::PathBuf;

--- a/bld_config/src/lib.rs
+++ b/bld_config/src/lib.rs
@@ -4,6 +4,7 @@ mod errors;
 mod local;
 mod path;
 mod remote;
+mod tls;
 mod server;
 mod supervisor;
 
@@ -12,6 +13,7 @@ pub use errors::*;
 pub use local::*;
 pub use path::*;
 pub use remote::*;
+pub use tls::*;
 pub use server::*;
 pub use supervisor::*;
 

--- a/bld_config/src/local.rs
+++ b/bld_config/src/local.rs
@@ -73,9 +73,17 @@ impl BldLocalConfig {
         debug!("server > host: {}", self.server.host);
         debug!("server > port: {}", self.server.port);
         debug!("server > pipelines: {}", self.server.pipelines);
+        if let Some(tls) = &self.server.tls {
+            debug!("server > tls > cert-chain: {}", tls.cert_chain);
+            debug!("server > tls > private-key: {}", tls.private_key);
+        }
         debug!("supervisor > host {}", self.supervisor.host);
         debug!("supervisor > port {}", self.supervisor.port);
         debug!("supervisor > workers {}", self.supervisor.workers);
+        if let Some(tls) = &self.supervisor.tls {
+            debug!("supervisor > tls > cert-chain: {}", tls.cert_chain);
+            debug!("supervisor > tls > private-key: {}", tls.private_key);
+        }
         debug!("logs: {}", self.logs);
         debug!("db: {}", self.db);
         debug!("docker-url: {}", self.docker_url);

--- a/bld_config/src/server.rs
+++ b/bld_config/src/server.rs
@@ -1,5 +1,5 @@
 use crate::definitions;
-use crate::{Auth, OAuth2Info, BldTlsConfig};
+use crate::{Auth, BldTlsConfig, OAuth2Info};
 use anyhow::{anyhow, Result};
 use async_raft::NodeId;
 use yaml_rust::Yaml;
@@ -86,14 +86,14 @@ impl BldRemoteServerConfig {
         let port = yaml["port"]
             .as_i64()
             .ok_or_else(|| anyhow!("Server entry must define a port"))?;
-        let tls = yaml["tls"]
-            .as_bool()
-            .unwrap_or(false);
+        let tls = yaml["tls"].as_bool().unwrap_or(false);
         let protocol = Self::http_protocol_internal(tls);
         let node_id = yaml["node-id"].as_i64().map(|n| n as NodeId);
         let auth = match yaml["auth"]["method"].as_str() {
             Some("ldap") => Auth::Ldap,
-            Some("oauth2") => Auth::OAuth2(OAuth2Info::load(&host, port, &protocol, &yaml["auth"])?),
+            Some("oauth2") => {
+                Auth::OAuth2(OAuth2Info::load(&host, port, &protocol, &yaml["auth"])?)
+            }
             _ => Auth::None,
         };
         let same_auth_as = yaml["same-auth-as"].as_str().map(|s| s.to_string());

--- a/bld_config/src/supervisor.rs
+++ b/bld_config/src/supervisor.rs
@@ -32,7 +32,7 @@ impl BldLocalSupervisorConfig {
         })
     }
 
-    pub fn protocol(&self) -> String {
+    pub fn http_protocol(&self) -> String {
         if self.tls.is_some() {
             "https".to_string()
         } else {

--- a/bld_config/src/supervisor.rs
+++ b/bld_config/src/supervisor.rs
@@ -31,6 +31,22 @@ impl BldLocalSupervisorConfig {
             workers,
         })
     }
+
+    pub fn protocol(&self) -> String {
+        if self.tls.is_some() {
+            "https".to_string()
+        } else {
+            "http".to_string()
+        }
+    }
+
+    pub fn ws_protocol(&self) -> String {
+        if self.tls.is_some() {
+            "wss".to_string()
+        } else {
+            "ws".to_string()
+        }
+    }
 }
 
 impl Default for BldLocalSupervisorConfig {

--- a/bld_config/src/supervisor.rs
+++ b/bld_config/src/supervisor.rs
@@ -1,4 +1,5 @@
 use crate::definitions;
+use crate::BldTlsConfig;
 use anyhow::Result;
 use yaml_rust::Yaml;
 
@@ -6,6 +7,7 @@ use yaml_rust::Yaml;
 pub struct BldLocalSupervisorConfig {
     pub host: String,
     pub port: i64,
+    pub tls: Option<BldTlsConfig>,
     pub workers: i64,
 }
 
@@ -18,12 +20,14 @@ impl BldLocalSupervisorConfig {
         let port = yaml["port"]
             .as_i64()
             .unwrap_or(definitions::LOCAL_SUPERVISOR_PORT);
+        let tls = BldTlsConfig::load(&yaml["tls"])?;
         let workers = yaml["workers"]
             .as_i64()
             .unwrap_or(definitions::LOCAL_SUPERVISOR_WORKERS);
         Ok(Self {
             host,
             port,
+            tls,
             workers,
         })
     }
@@ -34,6 +38,7 @@ impl Default for BldLocalSupervisorConfig {
         Self {
             host: definitions::LOCAL_SUPERVISOR_HOST.to_string(),
             port: definitions::LOCAL_SUPERVISOR_PORT,
+            tls: None,
             workers: definitions::LOCAL_SUPERVISOR_WORKERS,
         }
     }

--- a/bld_config/src/tls.rs
+++ b/bld_config/src/tls.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 use yaml_rust::Yaml;
-use tracing::debug;
 
 #[derive(Debug)]
 pub struct BldTlsConfig {

--- a/bld_config/src/tls.rs
+++ b/bld_config/src/tls.rs
@@ -1,0 +1,29 @@
+use anyhow::{anyhow, Result};
+use yaml_rust::Yaml;
+use tracing::debug;
+
+#[derive(Debug)]
+pub struct BldTlsConfig {
+    pub cert_chain: String,
+    pub private_key: String,
+}
+
+impl BldTlsConfig {
+    pub fn load(yaml: &Yaml) -> Result<Option<Self>> {
+        if yaml.is_badvalue() {
+            return Ok(None);
+        }
+        let cert_chain = yaml["cert-chain"]
+            .as_str()
+            .ok_or_else(|| anyhow!("certificate chain file not provided"))?
+            .to_string();
+        let private_key = yaml["private-key"]
+            .as_str()
+            .ok_or_else(|| anyhow!("private key file not provided"))?
+            .to_string();
+        Ok(Some(Self {
+            cert_chain,
+            private_key
+        }))
+    }
+}

--- a/bld_config/src/tls.rs
+++ b/bld_config/src/tls.rs
@@ -22,7 +22,7 @@ impl BldTlsConfig {
             .to_string();
         Ok(Some(Self {
             cert_chain,
-            private_key
+            private_key,
         }))
     }
 }

--- a/bld_core/src/high_avail/agent.rs
+++ b/bld_core/src/high_avail/agent.rs
@@ -7,14 +7,16 @@ pub struct Agent {
     id: NodeId,
     host: String,
     port: i64,
+    protocol: String,
 }
 
 impl Agent {
-    pub fn new(id: NodeId, host: &str, port: i64) -> Self {
+    pub fn new(id: NodeId, host: &str, port: i64, protocol: &str) -> Self {
         Self {
             id,
             host: host.to_string(),
             port,
+            protocol: protocol.to_string(),
         }
     }
 
@@ -28,6 +30,10 @@ impl Agent {
 
     pub fn port(&self) -> i64 {
         self.port
+    }
+
+    pub fn protocol(&self) -> &str {
+        &self.protocol
     }
 }
 

--- a/bld_core/src/high_avail/mod.rs
+++ b/bld_core/src/high_avail/mod.rs
@@ -77,7 +77,12 @@ fn agent_info(config: &BldConfig) -> Result<(Agent, HashSet<Agent>)> {
         let node_id = server
             .node_id
             .ok_or_else(|| anyhow!("server: {}, node_id not found", server.name))?;
-        agents.insert(Agent::new(node_id, &server.host, server.port, &server.http_protocol()));
+        agents.insert(Agent::new(
+            node_id,
+            &server.host,
+            server.port,
+            &server.http_protocol(),
+        ));
     }
     agents.insert(agent.clone());
     Ok((agent, agents))

--- a/bld_core/src/high_avail/mod.rs
+++ b/bld_core/src/high_avail/mod.rs
@@ -70,13 +70,14 @@ fn agent_info(config: &BldConfig) -> Result<(Agent, HashSet<Agent>)> {
         .local
         .node_id
         .ok_or_else(|| anyhow!("node_id not found"))?;
-    let agent = Agent::new(node_id, &config.local.server.host, config.local.server.port);
+    let server = &config.local.server;
+    let agent = Agent::new(node_id, &server.host, server.port, &server.http_protocol());
     let mut agents = HashSet::new();
     for server in config.remote.servers.iter() {
         let node_id = server
             .node_id
             .ok_or_else(|| anyhow!("server: {}, node_id not found", server.name))?;
-        agents.insert(Agent::new(node_id, &server.host, server.port));
+        agents.insert(Agent::new(node_id, &server.host, server.port, &server.http_protocol()));
     }
     agents.insert(agent.clone());
     Ok((agent, agents))

--- a/bld_runner/Cargo.toml
+++ b/bld_runner/Cargo.toml
@@ -10,7 +10,7 @@ actix = "0.13.0"
 actix-codec = "0.5.0"
 actix-web = { version = "4.0.1", features = ["openssl"] }
 actix-web-actors = "4.1.0"
-awc = "3.0.0"
+awc = { version = "3.0.0", features = ["openssl"] }
 anyhow = "1.0.40"
 bld_config = { path = "../bld_config" }
 bld_utils = { path = "../bld_utils" }

--- a/bld_runner/src/socket/mod.rs
+++ b/bld_runner/src/socket/mod.rs
@@ -5,7 +5,8 @@ use crate::socket::client::ExecClient;
 use crate::socket::messages::ExecInfo;
 use actix::{io::SinkWrite, Actor, StreamHandler};
 use actix_web::rt::System;
-use anyhow::anyhow;
+use anyhow::{anyhow, Result};
+use awc::http::Version;
 use awc::Client;
 use futures::stream::StreamExt;
 use std::collections::HashMap;
@@ -22,23 +23,31 @@ pub struct ExecConnectionInfo {
     pub variables: HashMap<String, String>,
 }
 
-async fn remote_invoke(info: ExecConnectionInfo) -> anyhow::Result<()> {
+async fn remote_invoke(info: ExecConnectionInfo) -> Result<()> {
     let url = format!("{}://{}:{}/ws-exec/", info.protocol, info.host, info.port);
+
     debug!("establishing web socker connection on {}", url);
-    let mut client = Client::new().ws(url);
+
+    let client = Client::builder()
+        .max_http_version(Version::HTTP_11)
+        .finish();
+    let mut client = client.ws(url);
     for (key, value) in info.headers.iter() {
         client = client.header(&key[..], &value[..]);
     }
+
     let (_, framed) = client.connect().await.map_err(|e| anyhow!(e.to_string()))?;
     let (sink, stream) = framed.split();
     let addr = ExecClient::create(|ctx| {
         ExecClient::add_stream(stream, ctx);
         ExecClient::new(SinkWrite::new(sink, ctx))
     });
+
     debug!(
         "sending data over: {:?} {:?}",
         info.pipeline, info.variables
     );
+
     if info.detach {
         addr.do_send(ExecInfo::new(
             &info.pipeline,
@@ -56,7 +65,7 @@ async fn remote_invoke(info: ExecConnectionInfo) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn on_server(info: ExecConnectionInfo) -> anyhow::Result<()> {
+pub fn on_server(info: ExecConnectionInfo) -> Result<()> {
     debug!("spawing actix system");
     let sys = System::new();
     let res = sys.block_on(remote_invoke(info));

--- a/bld_runner/src/socket/mod.rs
+++ b/bld_runner/src/socket/mod.rs
@@ -14,6 +14,7 @@ use tracing::debug;
 pub struct ExecConnectionInfo {
     pub host: String,
     pub port: i64,
+    pub protocol: String,
     pub headers: HashMap<String, String>,
     pub detach: bool,
     pub pipeline: String,
@@ -22,7 +23,7 @@ pub struct ExecConnectionInfo {
 }
 
 async fn remote_invoke(info: ExecConnectionInfo) -> anyhow::Result<()> {
-    let url = format!("ws://{}:{}/ws-exec/", info.host, info.port);
+    let url = format!("{}://{}:{}/ws-exec/", info.protocol, info.host, info.port);
     debug!("establishing web socker connection on {}", url);
     let mut client = Client::new().ws(url);
     for (key, value) in info.headers.iter() {

--- a/bld_server/Cargo.toml
+++ b/bld_server/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1.0.64"
 tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1.36"
 uuid = { version = "0.8.2", features = ["v4"] }
+openssl = "0.10.42"

--- a/bld_server/Cargo.toml
+++ b/bld_server/Cargo.toml
@@ -11,7 +11,7 @@ actix-codec = "0.5.0"
 actix-http = "3.0.4"
 actix-web = { version = "4.0.1", features = ["openssl"] }
 actix-web-actors = "4.1.0"
-awc = "3.0.0"
+awc = { version = "3.0.0", features = ["openssl"] }
 anyhow = "1.0.40"
 async-raft = "0.6.1"
 bld_config = { path = "../bld_config" }

--- a/bld_server/src/server.rs
+++ b/bld_server/src/server.rs
@@ -89,9 +89,10 @@ async fn supervisor_socket(
     config: Arc<BldConfig>,
     mut enqueue_rx: Receiver<ServerMessages>,
 ) -> Result<Addr<EnqueueClient>> {
+    let supervisor = &config.local.supervisor;
     let url = format!(
-        "ws://{}:{}/ws-server/",
-        config.local.supervisor.host, config.local.supervisor.port
+        "{}://{}:{}/ws-server/",
+        supervisor.ws_protocol(), supervisor.host, supervisor.port
     );
 
     debug!("establishing web socket connection on {}", url);

--- a/bld_supervisor/Cargo.toml
+++ b/bld_supervisor/Cargo.toml
@@ -25,3 +25,4 @@ shiplift = "0.7.0"
 tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1.36"
 uuid = { version = "0.8.2", features = ["v4"] }
+openssl = "0.10.42"

--- a/bld_supervisor/Cargo.toml
+++ b/bld_supervisor/Cargo.toml
@@ -11,7 +11,7 @@ actix-codec = "0.5.0"
 actix-http = "3.0.4"
 actix-web = { version = "4.0.1", features = ["openssl"] }
 actix-web-actors = "4.1.0"
-awc = "3.0.0"
+awc = { version = "3.0.0", features = ["openssl"] }
 anyhow = "1.0.40"
 async-trait = "0.1.50"
 bld_config = { path = "../bld_config" }

--- a/bld_supervisor/src/supervisor.rs
+++ b/bld_supervisor/src/supervisor.rs
@@ -2,10 +2,10 @@ use crate::queues::WorkerQueue;
 use crate::sockets::{ws_server_socket, ws_worker_socket};
 use actix_web::web::{get, resource, Data};
 use actix_web::{App, HttpServer};
-use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
 use bld_core::database::new_connection_pool;
+use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use std::sync::Mutex;
 
 pub async fn start(config: BldConfig) -> Result<()> {
@@ -38,7 +38,7 @@ pub async fn start(config: BldConfig) -> Result<()> {
             builder.set_certificate_chain_file(&tls.cert_chain)?;
             server.bind_openssl(address, builder)?
         }
-        None => server.bind(address)?
+        None => server.bind(address)?,
     };
 
     server.run().await.map_err(|e| anyhow!(e))

--- a/bld_supervisor/src/supervisor.rs
+++ b/bld_supervisor/src/supervisor.rs
@@ -2,33 +2,44 @@ use crate::queues::WorkerQueue;
 use crate::sockets::{ws_server_socket, ws_worker_socket};
 use actix_web::web::{get, resource, Data};
 use actix_web::{App, HttpServer};
-use anyhow::anyhow;
+use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
 use bld_core::database::new_connection_pool;
 use std::sync::Mutex;
 
-pub async fn start(config: BldConfig) -> anyhow::Result<()> {
-    let url = format!(
+pub async fn start(config: BldConfig) -> Result<()> {
+    let address = format!(
         "{}:{}",
         config.local.supervisor.host, config.local.supervisor.port
     );
     let config = Data::new(config);
+    let config_clone = config.clone();
     let pool = Data::new(new_connection_pool(&config.local.db)?);
     let worker_queue = Data::new(Mutex::new(WorkerQueue::new(
         config.local.supervisor.workers.try_into()?,
         config.clone(),
         pool.clone(),
     )));
-    HttpServer::new(move || {
+
+    let mut server = HttpServer::new(move || {
         App::new()
-            .app_data(config.clone())
+            .app_data(config_clone.clone())
             .app_data(pool.clone())
             .app_data(worker_queue.clone())
             .service(resource("/ws-server/").route(get().to(ws_server_socket)))
             .service(resource("/ws-worker/").route(get().to(ws_worker_socket)))
-    })
-    .bind(url)?
-    .run()
-    .await
-    .map_err(|e| anyhow!(e))
+    });
+
+    server = match &config.local.supervisor.tls {
+        Some(tls) => {
+            let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
+            builder.set_private_key_file(&tls.private_key, SslFiletype::PEM)?;
+            builder.set_certificate_chain_file(&tls.cert_chain)?;
+            server.bind_openssl(address, builder)?
+        }
+        None => server.bind(address)?
+    };
+
+    server.run().await.map_err(|e| anyhow!(e))
 }

--- a/bld_utils/src/request.rs
+++ b/bld_utils/src/request.rs
@@ -31,7 +31,7 @@ pub async fn get(url: String, headers: HashMap<String, String>) -> Result<String
             Err(anyhow!(msg))
         }
         st => Err(anyhow!(
-            "http request returned failed with status code: {}",
+            "request returned failed with status code: {}",
             st.to_string()
         )),
     }


### PR DESCRIPTION
In this PR:

- Added new local configuration to se tls options for both the server and supervisor. These options are:
    - The certificate chain.
    - The private key.
- Added new remote configuration to set a boolean flag indicating the communication will use TLS or not.
- Made changes to include the new configuration in the output of the config command.
- Made changes to remove hard coded protocols as http and ws.
- For wss:// connection the http version is set to 1.1 since http 2 raised errors.