### PR TITLE
Bugfix/deps-endpoint-wrong-return-type

### DIFF
--- a/crates/bld_server/src/endpoints/deps.rs
+++ b/crates/bld_server/src/endpoints/deps.rs
@@ -1,6 +1,7 @@
 use crate::extractors::User;
 use actix_web::web::{Data, Json};
 use actix_web::{post, HttpResponse, Responder};
+use anyhow::Result;
 use bld_core::proxies::PipelineFileSystemProxy;
 use bld_runner::VersionedPipeline;
 use tracing::info;
@@ -13,8 +14,13 @@ pub async fn deps(
 ) -> impl Responder {
     info!("Reached handler for /deps route");
     let name = body.into_inner();
-    match VersionedPipeline::dependencies(prx.get_ref(), &name) {
+    match do_deps(prx.get_ref(), &name) {
         Ok(r) => HttpResponse::Ok().json(r),
         Err(e) => HttpResponse::BadRequest().body(e.to_string()),
     }
+}
+
+pub fn do_deps(prx: &PipelineFileSystemProxy, name: &str) -> Result<Vec<String>> {
+    let dependencies = VersionedPipeline::dependencies(prx, name)?;
+    Ok(dependencies.into_keys().collect())
 }


### PR DESCRIPTION
Changes to the deps endpoint.

* The endpoint now correctly returns the hashmap's keys.