### PR TITLE
Task/add jobs section

### DIFF
--- a/.nvim/launch.lua
+++ b/.nvim/launch.lua
@@ -5,12 +5,15 @@ return {
       type = 'lldb',
       request = 'launch',
       program = function()
-        return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+        return vim.fn.getcwd() .. '/target/debug/bld'
       end,
       cwd = '${workspaceFolder}',
       stopOnEntry = false,
-      args = {'check', '-p', 'sample.yaml'},
-      prelaunchTask = "cargo build"
+      args = {'check', '-p', 'build-musl.yaml'},
+      prelaunchTask = function()
+        print("Building project...")
+        return "cargo build"
+      end
     },
     {
       name = 'Run pipeline',

--- a/crates/bld_core/src/platform/container.rs
+++ b/crates/bld_core/src/platform/container.rs
@@ -21,6 +21,7 @@ pub struct Container {
     pub client: Option<Docker>,
     pub context: Arc<ContextSender>,
     pub entity: Option<PipelineRunContainers>,
+    pub environment: Vec<String>,
 }
 
 impl Container {
@@ -68,6 +69,7 @@ impl Container {
             id: Some(id),
             context,
             entity,
+            environment: env,
         })
     }
 
@@ -102,8 +104,13 @@ impl Container {
             .or_else(|| Some(input.to_string()))
             .unwrap();
 
+        let env = self.environment.iter().map(String::as_str).collect();
+
+        dbg!(&env);
+
         let options = ExecContainerOptions::builder()
             .cmd(vec!["bash", "-c", &input])
+            .env(env)
             .attach_stdout(true)
             .attach_stderr(true)
             .build();

--- a/crates/bld_core/src/platform/image.rs
+++ b/crates/bld_core/src/platform/image.rs
@@ -44,7 +44,7 @@ pub enum Image {
 impl Image {
     async fn pull(client: &Docker, image: &str, logger: Arc<LoggerSender>) -> Result<String> {
         logger
-            .write_line(format!("{:<10}: {image}", "Pull"))
+            .write_line(format!("{:<15}: {image}", "Pull"))
             .await?;
 
         let pull_opts = PullOptionsBuilder::default().image(image).build();
@@ -73,7 +73,7 @@ impl Image {
         logger: Arc<LoggerSender>,
     ) -> Result<String> {
         logger
-            .write_line(format!("{:<10}: {dockerfile} to {tag}", "Build"))
+            .write_line(format!("{:<15}: {dockerfile} to {tag}", "Build"))
             .await?;
 
         let image = format!("{name}:{tag}");

--- a/crates/bld_core/src/platform/mod.rs
+++ b/crates/bld_core/src/platform/mod.rs
@@ -2,12 +2,16 @@ mod container;
 mod image;
 mod machine;
 
+use std::sync::Arc;
+
 pub use container::*;
 pub use image::*;
 pub use machine::*;
 use uuid::Uuid;
 
 use anyhow::Result;
+
+use crate::logger::LoggerSender;
 
 pub enum TargetPlatform {
     Machine {
@@ -57,10 +61,15 @@ impl TargetPlatform {
         }
     }
 
-    pub async fn shell(&self, working_dir: &Option<String>, command: &str) -> Result<()> {
+    pub async fn shell(
+        &self,
+        logger: Arc<LoggerSender>,
+        working_dir: &Option<String>,
+        command: &str,
+    ) -> Result<()> {
         match self {
-            Self::Machine { machine, .. } => machine.sh(working_dir, command).await,
-            Self::Container { container, .. } => container.sh(working_dir, command).await,
+            Self::Machine { machine, .. } => machine.sh(logger, working_dir, command).await,
+            Self::Container { container, .. } => container.sh(logger, working_dir, command).await,
         }
     }
 

--- a/crates/bld_runner/src/platform/builder.rs
+++ b/crates/bld_runner/src/platform/builder.rs
@@ -77,7 +77,7 @@ impl<'a> TargetPlatformBuilder<'a> {
                 TargetPlatform::container(Box::new(container))
             }
             None => {
-                let machine = Machine::new(run_id, environment, logger)?;
+                let machine = Machine::new(run_id, environment)?;
                 TargetPlatform::machine(Box::new(machine))
             }
         }

--- a/crates/bld_runner/src/platform/builder.rs
+++ b/crates/bld_runner/src/platform/builder.rs
@@ -14,6 +14,7 @@ pub struct TargetPlatformBuilder<'a> {
     run_id: Option<&'a str>,
     image: Option<Image>,
     config: Option<Arc<BldConfig>>,
+    pipeline_environment: Option<&'a HashMap<String, String>>,
     environment: Option<Arc<HashMap<String, String>>>,
     logger: Option<Arc<LoggerSender>>,
     context: Option<Arc<ContextSender>>,
@@ -32,6 +33,11 @@ impl<'a> TargetPlatformBuilder<'a> {
 
     pub fn config(mut self, config: Arc<BldConfig>) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    pub fn pipeline_environment(mut self, environment: &'a HashMap<String, String>) -> Self {
+        self.pipeline_environment = Some(environment);
         self
     }
 
@@ -59,6 +65,10 @@ impl<'a> TargetPlatformBuilder<'a> {
             .config
             .ok_or_else(|| anyhow!("no config provided for target platform builder"))?;
 
+        let pipeline_environment = self.pipeline_environment.ok_or_else(|| {
+            anyhow!("no pipeline environment provided for target platform builder")
+        })?;
+
         let environment = self
             .environment
             .ok_or_else(|| anyhow!("no environment provided for target platform builder"))?;
@@ -73,11 +83,19 @@ impl<'a> TargetPlatformBuilder<'a> {
 
         let platform = match self.image {
             Some(image) => {
-                let container = Container::new(image, config, environment, logger, context).await?;
+                let container = Container::new(
+                    image,
+                    config,
+                    pipeline_environment,
+                    environment,
+                    logger,
+                    context,
+                )
+                .await?;
                 TargetPlatform::container(Box::new(container))
             }
             None => {
-                let machine = Machine::new(run_id, environment)?;
+                let machine = Machine::new(run_id, pipeline_environment, environment)?;
                 TargetPlatform::machine(Box::new(machine))
             }
         }

--- a/crates/bld_runner/src/runner/v1.rs
+++ b/crates/bld_runner/src/runner/v1.rs
@@ -345,7 +345,9 @@ impl Runner {
         let command = self.apply_context(command);
 
         debug!("executing shell command {}", command);
-        self.platform.shell(&working_dir, &command).await?;
+        self.platform
+            .shell(self.logger.clone(), &working_dir, &command)
+            .await?;
 
         Ok(())
     }

--- a/crates/bld_runner/src/runner/v2.rs
+++ b/crates/bld_runner/src/runner/v2.rs
@@ -68,8 +68,8 @@ impl Job {
 
     async fn exec(&self, exec: &BuildStepExec, working_dir: &Option<String>) -> Result<()> {
         match exec {
-            BuildStepExec::Shell(cmd) => self.shell(working_dir, &cmd).await,
-            BuildStepExec::External { value } => self.external(&value).await,
+            BuildStepExec::Shell(cmd) => self.shell(working_dir, cmd).await,
+            BuildStepExec::External { value } => self.external(value).await,
         }
     }
 
@@ -104,7 +104,7 @@ impl Job {
             .pipeline
             .artifacts
             .iter()
-            .filter(|a| a.after.as_ref().map(|x| x.as_str()) == name)
+            .filter(|a| a.after.as_deref() == name)
         {
             let can_continue = artifact.method == *PUSH || artifact.method == *GET;
 
@@ -327,6 +327,7 @@ impl Runner {
             .run_id(&self.run_id)
             .config(self.config.clone())
             .image(image)
+            .pipeline_environment(&self.pipeline.environment)
             .environment(self.env.clone())
             .logger(self.logger.clone())
             .context(self.context.clone())

--- a/crates/bld_runner/src/step/v2.rs
+++ b/crates/bld_runner/src/step/v2.rs
@@ -30,10 +30,6 @@ impl BuildStep {
     }
 
     pub async fn apply_tokens<'a>(&mut self, context: &PipelineContext<'a>) -> Result<()> {
-        if let Some(name) = self.name.as_mut() {
-            self.name = Some(context.transform(name.to_owned()).await?);
-        }
-
         if let Some(working_dir) = self.working_dir.as_mut() {
             self.working_dir = Some(context.transform(working_dir.to_owned()).await?);
         }

--- a/crates/bld_runner/src/sync/builder.rs
+++ b/crates/bld_runner/src/sync/builder.rs
@@ -158,6 +158,7 @@ impl RunnerBuilder {
                     .run_id(&self.run_id)
                     .image(image)
                     .config(config.clone())
+                    .pipeline_environment(&pipeline.environment)
                     .environment(env.clone())
                     .logger(self.logger.clone())
                     .context(context.clone())

--- a/crates/bld_runner/src/sync/builder.rs
+++ b/crates/bld_runner/src/sync/builder.rs
@@ -4,6 +4,7 @@ use crate::pipeline::versioned::{VersionedPipeline, Yaml};
 use crate::platform::builder::TargetPlatformBuilder;
 use crate::runner::v1;
 use crate::runner::v2;
+use crate::token_context::v2::PipelineContextBuilder;
 use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
 use bld_core::context::ContextSender;
@@ -183,23 +184,37 @@ impl RunnerBuilder {
                 })
             }
 
-            VersionedPipeline::Version2(pipeline) => VersionedRunner::V2(v2::Runner {
-                run_id: self.run_id,
-                run_start_time: self.run_start_time,
-                config,
-                signals: self.signals,
-                logger: self.logger,
-                regex_cache: self.regex_cache,
-                proxy: self.proxy,
-                pipeline,
-                ipc: self.ipc,
-                env,
-                vars,
-                context,
-                platform: None,
-                is_child: self.is_child,
-                has_faulted: false,
-            }),
+            VersionedPipeline::Version2(mut pipeline) => {
+                let pipeline_context = PipelineContextBuilder::default()
+                    .bld_directory(&config.path)
+                    .add_variables(&pipeline.variables)
+                    .add_variables(&vars)
+                    .add_environment(&pipeline.environment)
+                    .add_environment(&env)
+                    .run_id(&self.run_id)
+                    .run_start_time(&self.run_start_time)
+                    .regex_cache(self.regex_cache.clone())
+                    .build()?;
+
+                pipeline.apply_tokens(&pipeline_context).await?;
+
+                VersionedRunner::V2(v2::Runner {
+                    run_id: self.run_id,
+                    run_start_time: self.run_start_time,
+                    config,
+                    signals: self.signals,
+                    logger: self.logger,
+                    regex_cache: self.regex_cache,
+                    proxy: self.proxy,
+                    pipeline: pipeline.into_arc(),
+                    ipc: self.ipc,
+                    env,
+                    context,
+                    platform: None,
+                    is_child: self.is_child,
+                    has_faulted: false,
+                })
+            }
         };
 
         Ok(runner)

--- a/crates/bld_runner/src/validator/v2.rs
+++ b/crates/bld_runner/src/validator/v2.rs
@@ -33,7 +33,7 @@ impl<'a> PipelineValidator<'a> {
             write!(errors, "{e}")?;
         }
 
-        if let Err(e) = self.validate_steps() {
+        if let Err(e) = self.validate_jobs() {
             write!(errors, "{e}")?;
         }
 
@@ -93,10 +93,10 @@ impl<'a> PipelineValidator<'a> {
         Ok(())
     }
 
-    fn validate_steps(&self) -> Result<()> {
+    fn validate_jobs(&self) -> Result<()> {
         let mut errors = String::new();
 
-        for step in &self.pipeline.steps {
+        for step in self.pipeline.jobs.iter().flat_map(|(_, steps)| steps) {
             for exec in &step.exec {
                 if let Err(e) = self.validate_exec(exec) {
                     writeln!(errors, "{e}")?;
@@ -156,13 +156,13 @@ impl<'a> PipelineValidator<'a> {
             return Ok(());
         };
 
-        if !self
-            .pipeline
-            .steps
-            .iter()
-            .any(|s| s.name.as_ref().map(|n| n == after).unwrap_or_default())
-        {
-            bail!("[artifacts > after: {after}] Not a declared step name");
+        if !self.pipeline.jobs.iter().any(|(name, steps)| {
+            name == after
+                || steps
+                    .iter()
+                    .any(|s| s.name.as_ref().map(|n| n == after).unwrap_or_default())
+        }) {
+            bail!("[artifacts > after: {after}] Not a declared job or step name");
         }
 
         Ok(())


### PR DESCRIPTION
In this PR:

- Added new section called jobs that replaces the top level steps. This enables jobs to run in parallel. If only one job is specified it is run synchronously.
- Added new type of logger for storing output in memory.
- Fixed an issue with the environment variables not being passed to the container or machine.