### PR TITLE
Task/additional subcommands

### DIFF
--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -1,10 +1,8 @@
-use std::fmt::Write;
-use std::process::{Command, ExitStatus};
-
-use anyhow::{bail, Result};
+use anyhow::Result;
 use bld_config::definitions::DEFAULT_V2_PIPELINE_CONTENT;
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
+use bld_utils::sync::IntoArc;
 use clap::Args;
 
 use crate::command::BldCommand;
@@ -27,44 +25,17 @@ pub struct AddCommand {
     edit: bool,
 }
 
-impl AddCommand {
-    fn create(&self) -> Result<()> {
-        let proxy = PipelineFileSystemProxy::Local;
-        let path = proxy.path(&self.pipeline)?;
-        if !path.is_file() {
-            proxy.create(&self.pipeline, DEFAULT_V2_PIPELINE_CONTENT)?;
-            println!("Pipeline file '{}' created successfully", self.pipeline);
-            Ok(())
-        } else {
-            bail!("Pipeline already exists")
-        }
-    }
-
-    fn edit(&self, config: &BldConfig) -> Result<()> {
-        if self.edit {
-            let proxy = PipelineFileSystemProxy::Local;
-            let path = proxy.path(&self.pipeline)?;
-
-            let mut edit_command = Command::new("/bin/bash");
-            edit_command.args(["-c", &format!("{} {}", config.local.editor, path.display())]);
-
-            let process_status = edit_command.status()?;
-            if !ExitStatus::success(&process_status) {
-                let mut error = String::new();
-                let process = edit_command.output()?;
-                writeln!(error, "editor process finished with {}", process.status)?;
-                write!(error, "{}", String::from_utf8_lossy(&process.stderr))?;
-                bail!(error);
-            }
-        }
-        Ok(())
-    }
-}
-
 impl BldCommand for AddCommand {
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?;
-        self.create()?;
-        self.edit(&config)
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config.clone());
+
+        proxy.create(&self.pipeline, DEFAULT_V2_PIPELINE_CONTENT)?;
+
+        if self.edit {
+            proxy.edit(&self.pipeline)?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -1,0 +1,70 @@
+use std::fmt::Write;
+use std::process::{Command, ExitStatus};
+
+use anyhow::{bail, Result};
+use bld_config::definitions::DEFAULT_V2_PIPELINE_CONTENT;
+use bld_config::BldConfig;
+use bld_core::proxies::PipelineFileSystemProxy;
+use clap::Args;
+
+use crate::command::BldCommand;
+
+#[derive(Args)]
+#[command(about = "Creates a new pipeline")]
+pub struct AddCommand {
+    #[arg(
+        short = 'p',
+        long = "pipeline",
+        help = "The path to the new pipeline file"
+    )]
+    pipeline: String,
+
+    #[arg(
+        short = 'e',
+        long = "edit",
+        help = "Edit the pipeline file immediatelly after creation"
+    )]
+    edit: bool,
+}
+
+impl AddCommand {
+    fn create(&self) -> Result<()> {
+        let proxy = PipelineFileSystemProxy::Local;
+        let path = proxy.path(&self.pipeline)?;
+        if !path.is_file() {
+            proxy.create(&self.pipeline, DEFAULT_V2_PIPELINE_CONTENT)?;
+            println!("Pipeline file '{}' created successfully", self.pipeline);
+            Ok(())
+        } else {
+            bail!("Pipeline already exists")
+        }
+    }
+
+    fn edit(&self, config: &BldConfig) -> Result<()> {
+        if self.edit {
+            let proxy = PipelineFileSystemProxy::Local;
+            let path = proxy.path(&self.pipeline)?;
+
+            let mut edit_command = Command::new("/bin/bash");
+            edit_command.args(["-c", &format!("{} {}", config.local.editor, path.display())]);
+
+            let process_status = edit_command.status()?;
+            if !ExitStatus::success(&process_status) {
+                let mut error = String::new();
+                let process = edit_command.output()?;
+                writeln!(error, "editor process finished with {}", process.status)?;
+                write!(error, "{}", String::from_utf8_lossy(&process.stderr))?;
+                bail!(error);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl BldCommand for AddCommand {
+    fn exec(self) -> Result<()> {
+        let config = BldConfig::load()?;
+        self.create()?;
+        self.edit(&config)
+    }
+}

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -51,7 +51,7 @@ impl AddCommand {
         Ok(())
     }
 
-    fn remove_add(self) -> Result<()> {
+    fn remote_add(self) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
             let proxy = PipelineFileSystemProxy::local(config.clone());
@@ -102,7 +102,7 @@ impl BldCommand for AddCommand {
         );
 
         match &self.server {
-            Some(_) => self.remove_add(),
+            Some(_) => self.remote_add(),
             None => self.local_add(),
         }
     }

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -1,9 +1,14 @@
-use anyhow::Result;
+use actix::System;
+use anyhow::{anyhow, Result};
 use bld_config::definitions::DEFAULT_V2_PIPELINE_CONTENT;
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
+use bld_server::requests::PushInfo;
+use bld_utils::request::Request;
 use bld_utils::sync::IntoArc;
 use clap::Args;
+use tracing::debug;
+use uuid::Uuid;
 
 use crate::command::BldCommand;
 
@@ -18,6 +23,13 @@ pub struct AddCommand {
     pipeline: String,
 
     #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to add the pipeline to"
+    )]
+    server: Option<String>,
+
+    #[arg(
         short = 'e',
         long = "edit",
         help = "Edit the pipeline file immediatelly after creation"
@@ -25,8 +37,8 @@ pub struct AddCommand {
     edit: bool,
 }
 
-impl BldCommand for AddCommand {
-    fn exec(self) -> Result<()> {
+impl AddCommand {
+    fn local_add(&self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
 
@@ -37,5 +49,61 @@ impl BldCommand for AddCommand {
         }
 
         Ok(())
+    }
+
+    fn remove_add(self) -> Result<()> {
+        System::new().block_on(async move {
+            let config = BldConfig::load()?.into_arc();
+            let proxy = PipelineFileSystemProxy::local(config.clone());
+            let server_name = self.server.ok_or_else(|| anyhow!("server not found"))?;
+            let server = config.server(&server_name)?;
+            let server_auth = config.same_auth_as(server)?;
+
+            let tmp_name = format!("{}{}", Uuid::new_v4(), self.pipeline);
+
+            println!("Creating temporary local pipeline {}", tmp_name);
+            debug!("creating temporary pipeline file: {tmp_name}");
+            proxy.create_tmp(&tmp_name, DEFAULT_V2_PIPELINE_CONTENT, true)?;
+
+            if self.edit {
+                println!("Editing temporary local pipeline {}", tmp_name);
+                debug!("starting editor for temporary pipeline file: {tmp_name}");
+                proxy.edit_tmp(&tmp_name)?;
+            }
+
+            debug!("reading content of temporary pipeline file: {tmp_name}");
+            let tmp_content = proxy.read_tmp(&tmp_name)?;
+
+            let push_url = format!("{}/push", server.base_url_http());
+            let push_info = PushInfo::new(&self.pipeline, &tmp_content);
+
+            println!("Pushing updated content for {}", self.pipeline);
+
+            debug!("sending request to {push_url}");
+
+            let _: String = Request::post(&push_url)
+                .auth(server_auth)
+                .send_json(&push_info)
+                .await?;
+
+            debug!("deleting temporary pipeline file: {tmp_name}");
+            proxy.remove_tmp(&tmp_name)?;
+
+            Ok(())
+        })
+    }
+}
+
+impl BldCommand for AddCommand {
+    fn exec(self) -> Result<()> {
+        debug!(
+            "running add subcommand with --server: {:?}, --pipeline: {} and --edit: {}",
+            self.server, self.pipeline, self.edit
+        );
+
+        match &self.server {
+            Some(_) => self.remove_add(),
+            None => self.local_add(),
+        }
     }
 }

--- a/crates/bld_commands/src/add/command.rs
+++ b/crates/bld_commands/src/add/command.rs
@@ -28,9 +28,9 @@ pub struct AddCommand {
 impl BldCommand for AddCommand {
     fn exec(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let proxy = PipelineFileSystemProxy::local(config.clone());
+        let proxy = PipelineFileSystemProxy::local(config);
 
-        proxy.create(&self.pipeline, DEFAULT_V2_PIPELINE_CONTENT)?;
+        proxy.create(&self.pipeline, DEFAULT_V2_PIPELINE_CONTENT, false)?;
 
         if self.edit {
             proxy.edit(&self.pipeline)?;

--- a/crates/bld_commands/src/add/mod.rs
+++ b/crates/bld_commands/src/add/mod.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::*;

--- a/crates/bld_commands/src/auth/command.rs
+++ b/crates/bld_commands/src/auth/command.rs
@@ -8,7 +8,11 @@ use tracing::debug;
 #[derive(Args)]
 #[command(about = "Initiates the login process for a bld server")]
 pub struct AuthCommand {
-    #[arg(short = 's', long = "server", help = "The target bld server")]
+    #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to login into"
+    )]
     server: Option<String>,
 }
 

--- a/crates/bld_commands/src/check/command.rs
+++ b/crates/bld_commands/src/check/command.rs
@@ -18,7 +18,7 @@ pub struct CheckCommand {
     #[arg(
         short = 's',
         long = "server",
-        help = "The name of the server to run the pipeline"
+        help = "The name of the server to check the pipeline from"
     )]
     server: Option<String>,
 }

--- a/crates/bld_commands/src/check/command.rs
+++ b/crates/bld_commands/src/check/command.rs
@@ -26,7 +26,7 @@ pub struct CheckCommand {
 impl CheckCommand {
     fn exec_local(&self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
-        let proxy = PipelineFileSystemProxy::Local.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config.clone()).into_arc();
         let content = proxy.read(&self.pipeline)?;
         let pipeline = Yaml::load_with_verbose_errors(&content)?;
         pipeline.validate_with_verbose_errors(config, proxy)

--- a/crates/bld_commands/src/check/command.rs
+++ b/crates/bld_commands/src/check/command.rs
@@ -24,7 +24,7 @@ pub struct CheckCommand {
 }
 
 impl CheckCommand {
-    fn exec_local(&self) -> Result<()> {
+    fn local_check(&self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config.clone()).into_arc();
         let content = proxy.read(&self.pipeline)?;
@@ -32,7 +32,7 @@ impl CheckCommand {
         pipeline.validate_with_verbose_errors(config, proxy)
     }
 
-    fn exec_server(&self, server: &str) -> Result<()> {
+    fn remote_check(&self, server: &str) -> Result<()> {
         let config = BldConfig::load()?;
         let server = config.server(server)?;
         let server_auth = config.same_auth_as(server)?;
@@ -51,8 +51,8 @@ impl CheckCommand {
 impl BldCommand for CheckCommand {
     fn exec(self) -> Result<()> {
         match &self.server {
-            Some(server) => self.exec_server(server),
-            None => self.exec_local(),
+            Some(server) => self.remote_check(server),
+            None => self.local_check(),
         }
     }
 }

--- a/crates/bld_commands/src/cli.rs
+++ b/crates/bld_commands/src/cli.rs
@@ -1,9 +1,9 @@
 use crate::add::AddCommand;
-use crate::edit::EditCommand;
 use crate::auth::AuthCommand;
 use crate::check::CheckCommand;
 use crate::command::BldCommand;
 use crate::config::ConfigCommand;
+use crate::edit::EditCommand;
 use crate::hist::HistCommand;
 use crate::init::InitCommand;
 use crate::inspect::InspectCommand;

--- a/crates/bld_commands/src/cli.rs
+++ b/crates/bld_commands/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::add::AddCommand;
 use crate::auth::AuthCommand;
 use crate::check::CheckCommand;
 use crate::command::BldCommand;
@@ -27,6 +28,7 @@ enum Commands {
     Config(ConfigCommand),
     Hist(HistCommand),
     Init(InitCommand),
+    Add(AddCommand),
     Inspect(InspectCommand),
     Ls(ListCommand),
     Monit(MonitCommand),
@@ -77,6 +79,7 @@ impl BldCommand for Cli {
             Commands::Config(config) => config.exec(),
             Commands::Hist(hist) => hist.exec(),
             Commands::Init(init) => init.exec(),
+            Commands::Add(add) => add.exec(),
             Commands::Inspect(inspect) => inspect.exec(),
             Commands::Ls(list) => list.exec(),
             Commands::Monit(monit) => monit.exec(),

--- a/crates/bld_commands/src/cli.rs
+++ b/crates/bld_commands/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::add::AddCommand;
+use crate::edit::EditCommand;
 use crate::auth::AuthCommand;
 use crate::check::CheckCommand;
 use crate::command::BldCommand;
@@ -26,6 +27,7 @@ enum Commands {
     Login(AuthCommand),
     Check(CheckCommand),
     Config(ConfigCommand),
+    Edit(EditCommand),
     Hist(HistCommand),
     Init(InitCommand),
     Add(AddCommand),
@@ -77,6 +79,7 @@ impl BldCommand for Cli {
             Commands::Login(auth) => auth.exec(),
             Commands::Check(check) => check.exec(),
             Commands::Config(config) => config.exec(),
+            Commands::Edit(edit) => edit.exec(),
             Commands::Hist(hist) => hist.exec(),
             Commands::Init(init) => init.exec(),
             Commands::Add(add) => add.exec(),

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -1,8 +1,12 @@
-use anyhow::Result;
+use actix::System;
+use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
-use bld_utils::sync::IntoArc;
+use bld_server::{requests::PushInfo, responses::PullResponse};
+use bld_utils::{request::Request, sync::IntoArc};
 use clap::Args;
+use tracing::debug;
+use uuid::Uuid;
 
 use crate::command::BldCommand;
 
@@ -10,13 +14,80 @@ use crate::command::BldCommand;
 #[command(about = "Edit a pipeline file")]
 pub struct EditCommand {
     #[arg(short = 'p', long = "pipline", help = "The name of the pipeline file")]
-    pipeline: String
+    pipeline: String,
+
+    #[arg(short = 's', long = "server", help = "The name of the bld server")]
+    server: Option<String>,
+}
+
+impl EditCommand {
+    fn local_edit(&self) -> Result<()> {
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
+        proxy.edit(&self.pipeline)
+    }
+
+    fn server_edit(self) -> Result<()> {
+        System::new().block_on(async move {
+            let config = BldConfig::load()?.into_arc();
+            let proxy = PipelineFileSystemProxy::local(config.clone());
+            let server_name = self.server.ok_or_else(|| anyhow!("server not found"))?;
+            let server = config.server(&server_name)?;
+            let server_auth = config.same_auth_as(server)?;
+            let pull_url = format!("{}/pull", server.base_url_http());
+
+            debug!(
+                "running edit subcommand with --server: {} and --pipeline: {}",
+                server_name, self.pipeline
+            );
+
+            println!("Pulling pipline {}", self.pipeline);
+
+            debug!("sending request to {pull_url}");
+
+            let data: PullResponse = Request::post(&pull_url)
+                .auth(server_auth)
+                .send_json(&self.pipeline)
+                .await?;
+
+            let tmp_name = format!("{}{}", Uuid::new_v4(), data.name);
+
+            println!("Editing temporary local pipeline {}", tmp_name);
+
+            debug!("creating temporary pipeline file: {tmp_name}");
+            proxy.create_tmp(&tmp_name, &data.content, true)?;
+
+            debug!("starting editor for temporary pipeline file: {tmp_name}");
+            proxy.edit_tmp(&tmp_name)?;
+
+            debug!("reading content of temporary pipeline file: {tmp_name}");
+            let tmp_content = proxy.read_tmp(&tmp_name)?;
+
+            let push_url = format!("{}/push", server.base_url_http());
+            let push_info = PushInfo::new(&self.pipeline, &tmp_content);
+
+            println!("Pushing updated content for {}", self.pipeline);
+
+            debug!("sending request to {push_url}");
+
+            let _: String = Request::post(&push_url)
+                .auth(server_auth)
+                .send_json(&push_info)
+                .await?;
+
+            debug!("deleting temporary pipeline file: {tmp_name}");
+            proxy.remove_tmp(&tmp_name)?;
+
+            Ok(())
+        })
+    }
 }
 
 impl BldCommand for EditCommand {
     fn exec(self) -> Result<()> {
-        let config = BldConfig::load()?.into_arc();
-        let proxy = PipelineFileSystemProxy::local(config);
-        proxy.edit(&self.pipeline)
+        match &self.server {
+            Some(_) => self.server_edit(),
+            None => self.local_edit(),
+        }
     }
 }

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -16,7 +16,11 @@ pub struct EditCommand {
     #[arg(short = 'p', long = "pipline", help = "The name of the pipeline file")]
     pipeline: String,
 
-    #[arg(short = 's', long = "server", help = "The name of the bld server")]
+    #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to edit the pipeline from"
+    )]
     server: Option<String>,
 }
 
@@ -27,7 +31,7 @@ impl EditCommand {
         proxy.edit(&self.pipeline)
     }
 
-    fn server_edit(self) -> Result<()> {
+    fn remove_edit(self) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
             let proxy = PipelineFileSystemProxy::local(config.clone());
@@ -35,11 +39,6 @@ impl EditCommand {
             let server = config.server(&server_name)?;
             let server_auth = config.same_auth_as(server)?;
             let pull_url = format!("{}/pull", server.base_url_http());
-
-            debug!(
-                "running edit subcommand with --server: {} and --pipeline: {}",
-                server_name, self.pipeline
-            );
 
             println!("Pulling pipline {}", self.pipeline);
 
@@ -85,8 +84,13 @@ impl EditCommand {
 
 impl BldCommand for EditCommand {
     fn exec(self) -> Result<()> {
+        debug!(
+            "running edit subcommand with --server: {:?} and --pipeline: {}",
+            self.server, self.pipeline
+        );
+
         match &self.server {
-            Some(_) => self.server_edit(),
+            Some(_) => self.remove_edit(),
             None => self.local_edit(),
         }
     }

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use bld_config::BldConfig;
+use bld_core::proxies::PipelineFileSystemProxy;
+use bld_utils::sync::IntoArc;
+use clap::Args;
+
+use crate::command::BldCommand;
+
+#[derive(Args)]
+#[command(about = "Edit a pipeline file")]
+pub struct EditCommand {
+    #[arg(short = 'p', long = "pipline", help = "The name of the pipeline file")]
+    pipeline: String
+}
+
+impl BldCommand for EditCommand {
+    fn exec(self) -> Result<()> {
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
+        proxy.edit(&self.pipeline)
+    }
+}

--- a/crates/bld_commands/src/edit/command.rs
+++ b/crates/bld_commands/src/edit/command.rs
@@ -31,7 +31,7 @@ impl EditCommand {
         proxy.edit(&self.pipeline)
     }
 
-    fn remove_edit(self) -> Result<()> {
+    fn remote_edit(self) -> Result<()> {
         System::new().block_on(async move {
             let config = BldConfig::load()?.into_arc();
             let proxy = PipelineFileSystemProxy::local(config.clone());
@@ -90,7 +90,7 @@ impl BldCommand for EditCommand {
         );
 
         match &self.server {
-            Some(_) => self.remove_edit(),
+            Some(_) => self.remote_edit(),
             None => self.local_edit(),
         }
     }

--- a/crates/bld_commands/src/edit/mod.rs
+++ b/crates/bld_commands/src/edit/mod.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::*;

--- a/crates/bld_commands/src/hist/command.rs
+++ b/crates/bld_commands/src/hist/command.rs
@@ -15,7 +15,7 @@ pub struct HistCommand {
     #[arg(
         short = 's',
         long = "server",
-        help = "The name of the server from which to fetch execution history"
+        help = "The name of the server to fetch history from"
     )]
     server: Option<String>,
 

--- a/crates/bld_commands/src/init/command.rs
+++ b/crates/bld_commands/src/init/command.rs
@@ -1,6 +1,9 @@
 use crate::command::BldCommand;
 use anyhow::{bail, Result};
-use bld_config::definitions;
+use bld_config::definitions::{
+    default_client_config, default_server_config, DEFAULT_V2_PIPELINE_CONTENT, LOCAL_DB,
+    LOCAL_LOGS, LOCAL_SERVER_PIPELINES, TOOL_DEFAULT_CONFIG_FILE, TOOL_DEFAULT_PIPELINE, TOOL_DIR,
+};
 use bld_config::path;
 use bld_utils::term::print_info;
 use clap::Args;
@@ -33,10 +36,7 @@ impl BldCommand for InitCommand {
                 .and_then(|_| create_default_yaml())
                 .and_then(|_| create_config_yaml(self.is_server));
         }
-        let message = format!(
-            "{} dir already exists in the current directory",
-            definitions::TOOL_DIR
-        );
+        let message = format!("{} dir already exists in the current directory", TOOL_DIR);
         bail!(message)
     }
 }
@@ -53,7 +53,7 @@ fn build_dir_exists() -> Result<bool> {
         if path.is_dir() {
             let component = path.components().last();
             if let Some(Normal(name)) = component {
-                if name == definitions::TOOL_DIR {
+                if name == TOOL_DIR {
                     return Ok(true);
                 }
             }
@@ -63,57 +63,51 @@ fn build_dir_exists() -> Result<bool> {
 }
 
 fn create_build_dir() -> Result<()> {
-    let path = Path::new(definitions::TOOL_DIR);
+    let path = Path::new(TOOL_DIR);
     create_dir(path)?;
-    print_dir_created(definitions::TOOL_DIR)?;
+    print_dir_created(TOOL_DIR)?;
     Ok(())
 }
 
 fn create_logs_dir(is_server: bool) -> Result<()> {
     if is_server {
-        let path = Path::new(definitions::LOCAL_LOGS);
+        let path = Path::new(LOCAL_LOGS);
         create_dir(path)?;
-        print_dir_created(definitions::LOCAL_LOGS)?;
+        print_dir_created(LOCAL_LOGS)?;
     }
     Ok(())
 }
 
 fn create_db_dir(is_server: bool) -> Result<()> {
     if is_server {
-        let path = Path::new(definitions::LOCAL_DB);
+        let path = Path::new(LOCAL_DB);
         create_dir(path)?;
-        print_dir_created(definitions::LOCAL_DB)?;
+        print_dir_created(LOCAL_DB)?;
     }
     Ok(())
 }
 
 fn create_server_pipelines_dir(is_server: bool) -> Result<()> {
     if is_server {
-        let path = Path::new(definitions::LOCAL_SERVER_PIPELINES);
+        let path = Path::new(LOCAL_SERVER_PIPELINES);
         create_dir(path)?;
-        print_dir_created(definitions::LOCAL_SERVER_PIPELINES)?;
+        print_dir_created(LOCAL_SERVER_PIPELINES)?;
     }
     Ok(())
 }
 
 fn create_default_yaml() -> Result<()> {
-    let path = path![
-        definitions::TOOL_DIR,
-        definitions::TOOL_DEFAULT_PIPELINE_FILE
-    ];
-    write(path, definitions::DEFAULT_PIPELINE_CONTENT)?;
-    print_info(&format!(
-        "{} yaml file created",
-        definitions::TOOL_DEFAULT_PIPELINE
-    ))?;
+    let path = path![TOOL_DIR, TOOL_DEFAULT_PIPELINE];
+    write(path, DEFAULT_V2_PIPELINE_CONTENT)?;
+    print_info(&format!("{} yaml file created", TOOL_DEFAULT_PIPELINE))?;
     Ok(())
 }
 
 fn create_config_yaml(is_server: bool) -> Result<()> {
-    let path = path![definitions::TOOL_DIR, definitions::TOOL_DEFAULT_CONFIG_FILE];
+    let path = path![TOOL_DIR, TOOL_DEFAULT_CONFIG_FILE];
     let content = match is_server {
-        true => definitions::default_server_config(),
-        false => definitions::default_client_config(),
+        true => default_server_config(),
+        false => default_client_config(),
     };
     write(path, content)?;
     print_info("config file created")?;

--- a/crates/bld_commands/src/inspect/command.rs
+++ b/crates/bld_commands/src/inspect/command.rs
@@ -3,7 +3,7 @@ use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
-use bld_utils::request::Request;
+use bld_utils::{request::Request, sync::IntoArc};
 use clap::Args;
 use tracing::debug;
 
@@ -28,7 +28,8 @@ pub struct InspectCommand {
 
 impl InspectCommand {
     fn local_exec(&self) -> Result<()> {
-        let proxy = PipelineFileSystemProxy::Local;
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
         let pipeline = proxy.read(&self.pipeline)?;
         println!("{pipeline}");
         Ok(())

--- a/crates/bld_commands/src/inspect/command.rs
+++ b/crates/bld_commands/src/inspect/command.rs
@@ -27,7 +27,7 @@ pub struct InspectCommand {
 }
 
 impl InspectCommand {
-    fn local_exec(&self) -> Result<()> {
+    fn local_inspect(&self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         let pipeline = proxy.read(&self.pipeline)?;
@@ -35,7 +35,7 @@ impl InspectCommand {
         Ok(())
     }
 
-    fn server_exec(&self, server: &str) -> Result<()> {
+    fn remote_inspect(&self, server: &str) -> Result<()> {
         let config = BldConfig::load()?;
         let server = config.server(server)?;
         let server_auth = config.same_auth_as(server)?;
@@ -55,8 +55,8 @@ impl InspectCommand {
 impl BldCommand for InspectCommand {
     fn exec(self) -> Result<()> {
         match &self.server {
-            Some(srv) => self.server_exec(srv),
-            None => self.local_exec(),
+            Some(srv) => self.remote_inspect(srv),
+            None => self.local_inspect(),
         }
     }
 }

--- a/crates/bld_commands/src/inspect/command.rs
+++ b/crates/bld_commands/src/inspect/command.rs
@@ -21,7 +21,7 @@ pub struct InspectCommand {
     #[arg(
         short = 's',
         long = "server",
-        help = "The name of the server from which to inspect the pipeline"
+        help = "The name of the server to inspect the pipeline from"
     )]
     server: Option<String>,
 }

--- a/crates/bld_commands/src/lib.rs
+++ b/crates/bld_commands/src/lib.rs
@@ -1,3 +1,4 @@
+mod add;
 mod auth;
 mod check;
 pub mod cli;

--- a/crates/bld_commands/src/lib.rs
+++ b/crates/bld_commands/src/lib.rs
@@ -4,6 +4,7 @@ mod check;
 pub mod cli;
 pub mod command;
 mod config;
+mod edit;
 mod hist;
 mod init;
 mod inspect;

--- a/crates/bld_commands/src/list/command.rs
+++ b/crates/bld_commands/src/list/command.rs
@@ -13,7 +13,7 @@ pub struct ListCommand {
     #[arg(
         short = 's',
         long = "server",
-        help = "The name of the server from which to fetch pipeline information"
+        help = "The name of the server to list pipelines from"
     )]
     server: Option<String>,
 }

--- a/crates/bld_commands/src/list/command.rs
+++ b/crates/bld_commands/src/list/command.rs
@@ -3,7 +3,7 @@ use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
-use bld_utils::request::Request;
+use bld_utils::{request::Request, sync::IntoArc};
 use clap::Args;
 use tracing::debug;
 
@@ -20,7 +20,9 @@ pub struct ListCommand {
 
 impl ListCommand {
     fn local_exec(&self) -> Result<()> {
-        let content = PipelineFileSystemProxy::Local.list()?.join("\n");
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
+        let content = proxy.list()?.join("\n");
         println!("{content}");
         Ok(())
     }

--- a/crates/bld_commands/src/list/command.rs
+++ b/crates/bld_commands/src/list/command.rs
@@ -19,7 +19,7 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    fn local_exec(&self) -> Result<()> {
+    fn local_list(&self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         let content = proxy.list()?.join("\n");
@@ -27,7 +27,7 @@ impl ListCommand {
         Ok(())
     }
 
-    fn server_exec(&self, server: &str) -> Result<()> {
+    fn remote_list(&self, server: &str) -> Result<()> {
         let config = BldConfig::load()?;
         let server = config.server(server)?;
         let server_auth = config.same_auth_as(server)?;
@@ -43,8 +43,8 @@ impl ListCommand {
 impl BldCommand for ListCommand {
     fn exec(self) -> Result<()> {
         match &self.server {
-            Some(srv) => self.server_exec(srv),
-            None => self.local_exec(),
+            Some(srv) => self.remote_list(srv),
+            None => self.local_list(),
         }
     }
 }

--- a/crates/bld_commands/src/monit/command.rs
+++ b/crates/bld_commands/src/monit/command.rs
@@ -30,7 +30,7 @@ pub struct MonitCommand {
     #[arg(
         short = 's',
         long = "server",
-        help = "The name of the server to monitor"
+        help = "The name of the server to monitor the pipeline from"
     )]
     server: Option<String>,
 

--- a/crates/bld_commands/src/pull/command.rs
+++ b/crates/bld_commands/src/pull/command.rs
@@ -4,13 +4,9 @@ use anyhow::{anyhow, Result};
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
 use bld_server::responses::PullResponse;
-use bld_utils::fs::IsYaml;
 use bld_utils::request::Request;
 use bld_utils::sync::IntoArc;
 use clap::Args;
-use std::fs::{create_dir_all, remove_file, File};
-use std::io::Write;
-use std::sync::Arc;
 use tracing::debug;
 
 #[derive(Args)]
@@ -37,6 +33,7 @@ pub struct PullCommand {
 impl PullCommand {
     async fn request(self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config.clone());
         let server = config.server_or_first(self.server.as_ref())?;
         let server_auth = config.same_auth_as(server)?;
 
@@ -73,35 +70,21 @@ impl PullCommand {
             debug!("sending http request to {}", url);
             print!("Pulling pipeline {pipeline}...");
 
-            Request::post(&url)
+            let data: PullResponse = Request::post(&url)
                 .auth(server_auth)
                 .send_json(pipeline)
                 .await
-                .and_then(|r| Self::save(config.clone(), r))
-                .map(|_| {
+                .map(|data| {
                     println!("Done.");
+                    data
                 })
-                .map_err(|e| {
-                    println!("Error. {e}");
-                    e
+                .map_err(|err| {
+                    println!("Error. {err}");
+                    err
                 })?;
+
+            proxy.create(&data.name, &data.content, true)?;
         }
-
-        Ok(())
-    }
-
-    fn save(config: Arc<BldConfig>, data: PullResponse) -> Result<()> {
-        let proxy = PipelineFileSystemProxy::local(config);
-        let path = proxy.path(&data.name)?;
-
-        if path.is_yaml() {
-            remove_file(&path)?;
-        } else if let Some(parent) = path.parent() {
-            create_dir_all(parent)?;
-        }
-
-        let mut handle = File::create(&path)?;
-        handle.write_all(data.content.as_bytes())?;
 
         Ok(())
     }

--- a/crates/bld_commands/src/pull/command.rs
+++ b/crates/bld_commands/src/pull/command.rs
@@ -20,7 +20,11 @@ pub struct PullCommand {
     )]
     pipeline: String,
 
-    #[arg(short = 's', long = "server", help = "The name of the bld server")]
+    #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to pull the pipeline from"
+    )]
     server: Option<String>,
 
     #[arg(

--- a/crates/bld_commands/src/remove/command.rs
+++ b/crates/bld_commands/src/remove/command.rs
@@ -22,13 +22,13 @@ pub struct RemoveCommand {
 }
 
 impl RemoveCommand {
-    fn local_exec(&self) -> Result<()> {
+    fn local_remove(&self) -> Result<()> {
         let config = BldConfig::load()?.into_arc();
         let proxy = PipelineFileSystemProxy::local(config);
         proxy.remove(&self.pipeline)
     }
 
-    fn server_exec(&self, server: &str) -> Result<()> {
+    fn remote_remove(&self, server: &str) -> Result<()> {
         let config = BldConfig::load()?;
         let server = config.server(server)?;
 
@@ -53,8 +53,8 @@ impl RemoveCommand {
 impl BldCommand for RemoveCommand {
     fn exec(self) -> Result<()> {
         match &self.server {
-            Some(srv) => self.server_exec(srv),
-            None => self.local_exec(),
+            Some(srv) => self.remote_remove(srv),
+            None => self.local_remove(),
         }
     }
 }

--- a/crates/bld_commands/src/remove/command.rs
+++ b/crates/bld_commands/src/remove/command.rs
@@ -3,7 +3,7 @@ use actix_web::rt::System;
 use anyhow::Result;
 use bld_config::BldConfig;
 use bld_core::proxies::PipelineFileSystemProxy;
-use bld_utils::request::Request;
+use bld_utils::{request::Request, sync::IntoArc};
 use clap::Args;
 use tracing::debug;
 
@@ -19,7 +19,9 @@ pub struct RemoveCommand {
 
 impl RemoveCommand {
     fn local_exec(&self) -> Result<()> {
-        PipelineFileSystemProxy::Local.remove(&self.pipeline)
+        let config = BldConfig::load()?.into_arc();
+        let proxy = PipelineFileSystemProxy::local(config);
+        proxy.remove(&self.pipeline)
     }
 
     fn server_exec(&self, server: &str) -> Result<()> {

--- a/crates/bld_commands/src/remove/command.rs
+++ b/crates/bld_commands/src/remove/command.rs
@@ -10,7 +10,11 @@ use tracing::debug;
 #[derive(Args)]
 #[command(about = "Removes a pipeline from a bld server")]
 pub struct RemoveCommand {
-    #[arg(short = 's', long = "server", help = "The name of the bld server")]
+    #[arg(
+        short = 's',
+        long = "server",
+        help = "The name of the server to remove from"
+    )]
     server: Option<String>,
 
     #[arg(short = 'p', long = "pipeline", help = "The name of the pipeline")]

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -36,6 +36,8 @@ pub const REMOTE_SERVER_HOST: &str = "127.0.0.1";
 pub const REMOTE_SERVER_PORT: i64 = 6080;
 pub const REMOTE_SERVER_OAUTH2: &str = ".bld/oauth2";
 
+pub const DEFAULT_EDITOR: &str = "vi";
+
 pub const DEFAULT_V1_PIPELINE_CONTENT: &str = r"runs_on: machine
 version: 1
 steps:

--- a/crates/bld_config/src/definitions.rs
+++ b/crates/bld_config/src/definitions.rs
@@ -36,10 +36,17 @@ pub const REMOTE_SERVER_HOST: &str = "127.0.0.1";
 pub const REMOTE_SERVER_PORT: i64 = 6080;
 pub const REMOTE_SERVER_OAUTH2: &str = ".bld/oauth2";
 
-pub const DEFAULT_PIPELINE_CONTENT: &str = r"runs_on: machine
+pub const DEFAULT_V1_PIPELINE_CONTENT: &str = r"runs_on: machine
 version: 1
 steps:
 - exec:
+  - echo 'hello world'
+";
+
+pub const DEFAULT_V2_PIPELINE_CONTENT: &str = r"runs_on: machine
+version: 2
+jobs:
+  main:
   - echo 'hello world'
 ";
 

--- a/crates/bld_config/src/local.rs
+++ b/crates/bld_config/src/local.rs
@@ -18,6 +18,9 @@ pub struct BldLocalConfig {
 
     #[serde(default = "BldLocalConfig::default_docker_url")]
     pub docker_url: String,
+
+    #[serde(default = "BldLocalConfig::default_editor")]
+    pub editor: String,
 }
 
 impl BldLocalConfig {
@@ -31,6 +34,10 @@ impl BldLocalConfig {
 
     fn default_docker_url() -> String {
         definitions::LOCAL_DOCKER_URL.to_owned()
+    }
+
+    fn default_editor() -> String {
+        definitions::DEFAULT_EDITOR.to_owned()
     }
 
     pub fn debug_info(&self) {
@@ -67,6 +74,7 @@ impl Default for BldLocalConfig {
             logs: Self::default_logs(),
             db: Self::default_db(),
             docker_url: Self::default_docker_url(),
+            editor: Self::default_editor(),
         }
     }
 }

--- a/crates/bld_server/src/endpoints/push.rs
+++ b/crates/bld_server/src/endpoints/push.rs
@@ -34,5 +34,5 @@ fn do_push(
         let id = Uuid::new_v4().to_string();
         pipeline::insert(&mut conn, &id, &info.name)?;
     }
-    prx.create(&info.name, &info.content)
+    prx.create(&info.name, &info.content, true)
 }


### PR DESCRIPTION
In this PR:
- Added the add subcommand.
- Added the edit subcommand.
- Extended the PipelineFileSystemProxy enum to support temporary pipelines and operations for them.
- Minor changes to some help text in various args of subcommands.